### PR TITLE
Add MS-AD Style Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,22 @@ docker run --privileged -d -p 389:389 rroemhild/test-openldap
 | ou               | Delivering Crew |
 | uid              | bender |
 | userPassword     | bender |
+
+### cn=admin_staff,ou=people,dc=planetexpress,dc=com
+
+| Attribute        | Value            |
+| ---------------- | ---------------- |
+| objectClass      | Group |
+| cn               | admin_staff |
+| member           | cn=Hubert J. Farnsworth,ou=people,dc=planetexpress,dc=com |
+| member           | cn=Hermes Conrad,ou=people,dc=planetexpress,dc=com |
+
+### cn=ship_crew,ou=people,dc=planetexpress,dc=com
+
+| Attribute        | Value            |
+| ---------------- | ---------------- |
+| objectClass      | Group |
+| cn               | ship_crew |
+| member           | cn=Turanga Leela,ou=people,dc=planetexpress,dc=com |
+| member           | cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com |
+| member           | cn=Bender Bending Rodríguez,ou=people,dc=planetexpress,dc=com |

--- a/bootstrap/config/msad.ldif
+++ b/bootstrap/config/msad.ldif
@@ -1,0 +1,19 @@
+version: 1
+
+# Add the groupType Attribute
+dn: cn=schema,cn=config
+changetype: modify
+add: olcAttributetypes
+olcAttributetypes: ( 1.2.840.113556.1.4.750 NAME 'groupType'
+   SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' SINGLE-VALUE
+ )
+
+# Add the group class
+dn: cn=schema,cn=config
+changetype: modify
+add: olcObjectClasses
+olcObjectClasses: ( 1.2.840.113556.1.5.8 NAME 'Group'
+        DESC 'a group of users'
+        SUP top STRUCTURAL
+        MUST ( groupType $ cn)
+        MAY ( member ) )

--- a/bootstrap/data/30_groups_admin.ldif
+++ b/bootstrap/data/30_groups_admin.ldif
@@ -1,0 +1,7 @@
+dn: cn=admin_staff,ou=people,dc=planetexpress,dc=com
+objectclass: Group
+objectclass: top
+groupType: 2147483650
+cn: admin_staff
+member: cn=Hubert J. Farnsworth,ou=people,dc=planetexpress,dc=com
+member: cn=Hermes Conrad,ou=people,dc=planetexpress,dc=com

--- a/bootstrap/data/30_groups_crew.ldif
+++ b/bootstrap/data/30_groups_crew.ldif
@@ -1,0 +1,8 @@
+dn: cn=ship_crew,ou=people,dc=planetexpress,dc=com
+objectclass: Group
+objectclass: top
+groupType: 2147483650
+cn: ship_crew
+member: cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com
+member: cn=Turanga Leela,ou=people,dc=planetexpress,dc=com
+member: cn=Bender Bending Rodríguez,ou=people,dc=planetexpress,dc=com

--- a/bootstrap/slapd-init.sh
+++ b/bootstrap/slapd-init.sh
@@ -61,6 +61,10 @@ configure_logging() {
     ldapmodify -Y EXTERNAL -H ldapi:/// -f ${CONFIG_DIR}/logging.ldif -Q
 }
 
+configure_msad_features(){
+  echo "Configure MS-AD Extensions"
+  ldapmodify -Y EXTERNAL -H ldapi:/// -f ${CONFIG_DIR}/msad.ldif -Q
+}
 
 load_initial_data() {
     echo "Load data..."
@@ -82,6 +86,7 @@ make_snakeoil_certificate
 chown -R openldap:openldap /etc/ldap
 slapd -h "ldapi:///" -u openldap -g openldap
 
+configure_msad_features
 configure_tls
 configure_logging
 load_initial_data


### PR DESCRIPTION
The application I am testing uses MS-AD groups for role-based authentication.  However my CI runs in a dockerized environment, which doesn't support running a full Windows Server.  So instead, I added Group objects (with the same schema as MS-AD) to OpenLDAP so I can test.  I think this could be useful to other users testing with groups, so I would like to push upsteam.

Unrelated note: love the Futurama theme!