### PR TITLE
Move MSAD LDAP config into core schema

### DIFF
--- a/bootstrap/config/msad.ldif
+++ b/bootstrap/config/msad.ldif
@@ -1,7 +1,7 @@
 version: 1
 
 # Add the groupType Attribute
-dn: cn=schema,cn=config
+dn: cn={0}core,cn=schema,cn=config
 changetype: modify
 add: olcAttributetypes
 olcAttributetypes: ( 1.2.840.113556.1.4.750 NAME 'groupType'
@@ -9,7 +9,7 @@ olcAttributetypes: ( 1.2.840.113556.1.4.750 NAME 'groupType'
  )
 
 # Add the group class
-dn: cn=schema,cn=config
+dn: cn={0}core,cn=schema,cn=config
 changetype: modify
 add: olcObjectClasses
 olcObjectClasses: ( 1.2.840.113556.1.5.8 NAME 'Group'


### PR DESCRIPTION
When running an `ldapsearch` for groups, no results are found:

```
$ ldapsearch -vvv -LLL -H ldap://localhost  -D 'cn=admin,dc=planetexpress,dc=com' -w GoodNewsEveryone -b dc=planetexpress,dc=com '(objectClass=Group)'
ldap_initialize( ldap://localhost:389/??base )
filter: (objectClass=Group)
requesting: All userApplication attributes
```
The logs show that the objectClass is unknown (with the `?objectClass`):
```
5a6345af conn=1001 fd=18 ACCEPT from IP=172.17.0.1:60528 (IP=0.0.0.0:389)
5a6345af conn=1001 op=0 BIND dn="cn=admin,dc=planetexpress,dc=com" method=128
5a6345af conn=1001 op=0 BIND dn="cn=admin,dc=planetexpress,dc=com" mech=SIMPLE ssf=0
5a6345af conn=1001 op=0 RESULT tag=97 err=0 text=
5a6345af conn=1001 op=1 SRCH base="dc=planetexpress,dc=com" scope=2 deref=0 filter="(?objectClass=Group)"
5a6345af conn=1001 op=1 SEARCH RESULT tag=101 err=0 nentries=0 text=
5a6345af conn=1001 op=2 UNBIND
5a6345af conn=1001 fd=18 closed
```

And dumping the schema doesn't show the MSAD schema modifications

```
$ docker exec openldap ldapsearch -H ldapi:/// -Y EXTERNAL -b cn=schema,cn=config | grep groupType
SASL/EXTERNAL authentication started
SASL username: gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth
SASL SSF: 0
```

By moving the MSAD schema into `cn={0}core,cn=schema,cn=config`, all of the above works. However, I'm still not completely sure why it didn't work properly before.

Search:
```
$ ldapsearch -vvv -LLL -H ldap://localhost  -D 'cn=admin,dc=planetexpress,dc=com' -w GoodNewsEveryone -b dc=planetexpress,dc=com '(objectClass=Group)'
ldap_initialize( ldap://localhost:389/??base )
filter: (objectClass=Group)
requesting: All userApplication attributes
dn: cn=admin_staff,ou=people,dc=planetexpress,dc=com
objectClass: Group
objectClass: top
groupType: 2147483650
cn: admin_staff
member: cn=Hubert J. Farnsworth,ou=people,dc=planetexpress,dc=com
member: cn=Hermes Conrad,ou=people,dc=planetexpress,dc=com

dn: cn=ship_crew,ou=people,dc=planetexpress,dc=com
objectClass: Group
objectClass: top
groupType: 2147483650
cn: ship_crew
member: cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com
member: cn=Turanga Leela,ou=people,dc=planetexpress,dc=com
member:: Y249QmVuZGVyIEJlbmRpbmcgUm9kcsOtZ3VleixvdT1wZW9wbGUsZGM9cGxhbmV0ZXhwc
 mVzcyxkYz1jb20=
```

Logs (notice the question mark no longer precedes `objectClass`):
```
5a63466e conn=1000 fd=18 ACCEPT from IP=172.17.0.1:60530 (IP=0.0.0.0:389)
5a63466e conn=1000 op=0 BIND dn="cn=admin,dc=planetexpress,dc=com" method=128
5a63466e conn=1000 op=0 BIND dn="cn=admin,dc=planetexpress,dc=com" mech=SIMPLE ssf=0
5a63466e conn=1000 op=0 RESULT tag=97 err=0 text=
5a63466e conn=1000 op=1 SRCH base="dc=planetexpress,dc=com" scope=2 deref=0 filter="(objectClass=Group)"
5a63466e conn=1000 op=1 SEARCH RESULT tag=101 err=0 nentries=2 text=
5a63466e conn=1000 op=2 UNBIND
5a63466e conn=1000 fd=18 closed
```

Schema dump:
```
$ docker exec openldap ldapsearch -H ldapi:/// -Y EXTERNAL -b cn=schema,cn=config | grep groupType
SASL/EXTERNAL authentication started
SASL username: gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth
SASL SSF: 0
olcAttributeTypes: {52}( 1.2.840.113556.1.4.750 NAME 'groupType'  SYNTAX '1.3.
 of users'       SUP top STRUCTURAL       MUST ( groupType $ cn)       MAY ( m
```