### PR TITLE
Add memberOf overlay

### DIFF
--- a/bootstrap/config/memberof.ldif
+++ b/bootstrap/config/memberof.ldif
@@ -1,0 +1,35 @@
+# Load memberof module
+dn: cn=module{0},cn=config
+changetype: modify
+add: olcModuleLoad
+olcModuleLoad: memberof
+
+# Backend memberOf overlay
+dn: olcOverlay={0}memberof,olcDatabase={1}hdb,cn=config
+changetype: add
+objectClass: olcOverlayConfig
+objectClass: olcMemberOf
+olcOverlay: {0}memberof
+olcMemberOfDangling: ignore
+olcMemberOfRefInt: TRUE
+olcMemberOfGroupOC: Group
+olcMemberOfMemberAD: member
+olcMemberOfMemberOfAD: memberOf
+
+# Load refint module
+dn: cn=module{0},cn=config
+changetype: modify
+add: olcModuleLoad
+olcModuleLoad: refint
+
+# Backend refint overlay
+dn: olcOverlay={1}refint,olcDatabase={1}hdb,cn=config
+changetype: add
+objectClass: olcOverlayConfig
+objectClass: olcRefintConfig
+olcOverlay: {1}refint
+olcRefintAttribute: owner
+olcRefintAttribute: manager
+olcRefintAttribute: uniqueMember
+olcRefintAttribute: member
+olcRefintAttribute: memberOf

--- a/bootstrap/slapd-init.sh
+++ b/bootstrap/slapd-init.sh
@@ -66,6 +66,11 @@ configure_msad_features(){
   ldapmodify -Y EXTERNAL -H ldapi:/// -f ${CONFIG_DIR}/msad.ldif -Q
 }
 
+configure_memberof_overlay(){
+  echo "Configure memberOf overlay..."
+  ldapmodify -Y EXTERNAL -H ldapi:/// -f ${CONFIG_DIR}/memberof.ldif -Q
+}
+
 load_initial_data() {
     echo "Load data..."
     local data=$(find ${DATA_DIR} -maxdepth 1 -name \*_\*.ldif -type f | sort)
@@ -89,6 +94,7 @@ slapd -h "ldapi:///" -u openldap -g openldap
 configure_msad_features
 configure_tls
 configure_logging
+configure_memberof_overlay
 load_initial_data
 
 kill -INT `cat /run/slapd/slapd.pid`


### PR DESCRIPTION
Hello,

This PR adds the `memberOf` overlay using the `memberof` and `refint` modules.
This will add the `memberOf` attribute to all members of a group with the DN of the group as the attribute's value.

**Example query:**
```
 ldapsearch -D "cn=admin,dc=planetexpress,dc=com" -w GoodNewsEveryone -p 389 -h 127.0.0.1 -b "dc=planetexpress,dc=com" -s sub "(&(objectClass=*))" memberOf
```

Btw, thanks for this great docker image :)