### PR TITLE
Add automatic config admin password replacement

### DIFF
--- a/bootstrap/config/configadminpw.ldif
+++ b/bootstrap/config/configadminpw.ldif
@@ -1,0 +1,4 @@
+dn: olcDatabase={0}config,cn=config
+changetype: modify
+add: olcRootPW
+olcRootPW: {ADMINPW}

--- a/bootstrap/slapd-init.sh
+++ b/bootstrap/slapd-init.sh
@@ -51,14 +51,14 @@ make_snakeoil_certificate() {
 
 
 configure_tls() {
-    echo "Configure TLS..."
-    ldapmodify -Y EXTERNAL -H ldapi:/// -f ${CONFIG_DIR}/tls.ldif -Q
+  echo "Configure TLS..."
+  ldapmodify -Y EXTERNAL -H ldapi:/// -f ${CONFIG_DIR}/tls.ldif -Q
 }
 
 
 configure_logging() {
-    echo "Configure logging..."
-    ldapmodify -Y EXTERNAL -H ldapi:/// -f ${CONFIG_DIR}/logging.ldif -Q
+  echo "Configure logging..."
+  ldapmodify -Y EXTERNAL -H ldapi:/// -f ${CONFIG_DIR}/logging.ldif -Q
 }
 
 configure_msad_features(){
@@ -69,6 +69,13 @@ configure_msad_features(){
 configure_memberof_overlay(){
   echo "Configure memberOf overlay..."
   ldapmodify -Y EXTERNAL -H ldapi:/// -f ${CONFIG_DIR}/memberof.ldif -Q
+}
+
+configure_admin_config_pw(){
+  echo "Configure admin config password..."
+  adminpw=$(slappasswd -h {SSHA} -s "${LDAP_SECRET}")
+  sed -i s/{ADMINPW}/${adminpw}/g ${CONFIG_DIR}/configadminpw.ldif
+  ldapmodify -Y EXTERNAL -H ldapi:/// -f ${CONFIG_DIR}/configadminpw.ldif -Q
 }
 
 load_initial_data() {
@@ -95,6 +102,7 @@ configure_msad_features
 configure_tls
 configure_logging
 configure_memberof_overlay
+configure_admin_config_pw
 load_initial_data
 
 kill -INT `cat /run/slapd/slapd.pid`


### PR DESCRIPTION
By default, OpenLDAP on Debian adds a default configuration admin user with a randomly generated root password. This PR adds a function that automatically changes this password to the `LDAP_SECRET` password on the initial startup.

This is super helpful when you programmatically want to update certain configurations (e.g. schema) within your unit-tests.