### PR TITLE
Added JAAS login config to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,27 @@ Amy has a multi-valued DN
 | member           | cn=Turanga Leela,ou=people,dc=planetexpress,dc=com |
 | member           | cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com |
 | member           | cn=Bender Bending Rodríguez,ou=people,dc=planetexpress,dc=com |
+
+
+## JAAS configuration
+
+In case you want to use this OpenLDAP server for testing with a Java-based
+application using JAAS and the `LdapLoginModule`, here's a working configuration
+file you can use to connect.
+
+```
+other {
+  com.sun.security.auth.module.LdapLoginModule REQUIRED
+    userProvider="ldap://localhost/ou=people,dc=planetexpress,dc=com"
+    userFilter="(&(uid={USERNAME})(objectClass=inetOrgPerson))"
+    useSSL=false
+    java.naming.security.principal="cn=admin,dc=planetexpress,dc=com"
+    java.naming.security.credentials="GoodNewsEveryone"
+    debug=true
+    ;
+};
+```
+
+This config uses the admin credentials to connect to the OpenLDAP server and to
+submit the search query for the user that enters their credentials. As username
+the `uid` attribute of each entry is used.


### PR DESCRIPTION
First of all, thank you for this super-easy to use Docker image! I used it to test some of my Java authentication logic which makes use of JAAS and the `LdapLoginModule`. However, it took me a couple of hours to get the login configuration to the OpenLDAP server right. To spare future users of your image the hazzle (and also to increase the number of sample JAAS login configs out there) I thought I contribute back and add it to the README.