### PR TITLE
fixes #9: Add SSL port to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Flask extension [flask-ldapconn][flaskldapconn] use this image for unit test
 
 ```
 docker pull rroemhild/test-openldap
-docker run --privileged -d -p 389:389 rroemhild/test-openldap
+docker run --privileged -d -p 389:389 -p 636:636 rroemhild/test-openldap
 ```
 
 ## Exposed ports


### PR DESCRIPTION
Updating the example command to include the SSL port. This, obviously, isn't strictly needed, but at least two people (yours truly included) have spent to much time trying to figure out why StartTLS works, but LDAPS doesn't...