### PR TITLE
Add automatic config admin password replacement #14, escaping sed characters

### DIFF
--- a/bootstrap/slapd-init.sh
+++ b/bootstrap/slapd-init.sh
@@ -69,6 +69,7 @@ configure_msad_features(){
 configure_admin_config_pw(){
   echo "Configure admin config password..."
   adminpw=$(slappasswd -h {SSHA} -s "${LDAP_SECRET}")
+  adminpw=$(printf '%s\n' "$adminpw" | sed -e 's/[\/&]/\\&/g')
   sed -i s/ADMINPW/${adminpw}/g ${CONFIG_DIR}/configadminpw.ldif
   ldapmodify -Y EXTERNAL -H ldapi:/// -f ${CONFIG_DIR}/configadminpw.ldif -Q
 }


### PR DESCRIPTION
Hi and thanks for your project! I have been looking for an easy way to run AD integration tests and your project was exactly what I needed.

But sometimes when I build the image the _slappasswd_ salted password contains characters that needs to be escaped for use with _sed_. I've added a line in _slapd-init.sh_ that escapes the password.

**Examples of build failures:**

docker build . -t rroemhild/docker-test-openldap

```
+ configure_admin_config_pw
+ echo 'Configure admin config password...'
Configure admin config password...
++ slappasswd -h '{SSHA}' -s GoodNewsEveryone
+ adminpw='{SSHA}dMRxzMI4+Ef13/oj5V496x9AcYLan/Iz'
+ sed -i 's/ADMINPW/{SSHA}dMRxzMI4+Ef13/oj5V496x9AcYLan/Iz/g' /bootstrap/config/configadminpw.ldif
sed: -e expression #1, char 31: unknown option to `s'
```

```
+ configure_admin_config_pw
Configure admin config password...
+ echo 'Configure admin config password...'
++ slappasswd -h '{SSHA}' -s GoodNewsEveryone
+ adminpw='{SSHA}MgDOk2BtkagO1fsmB/O4Hdj39l9DIDFE'
+ sed -i 's/ADMINPW/{SSHA}MgDOk2BtkagO1fsmB/O4Hdj39l9DIDFE/g' /bootstrap/config/configadminpw.ldif
sed: -e expression #1, char 35: unknown option to `s'
```

The escape code is taken from here: https://stackoverflow.com/questions/407523/escape-a-string-for-a-sed-replace-pattern