### PR TITLE
Add subjectAltName to cert for modern Go clients

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
 # ADD bootstrap files
 ADD ./bootstrap /bootstrap
 
+ARG CERT_SAN
+
 # Initialize LDAP with data
 RUN /bin/bash /bootstrap/slapd-init.sh
 

--- a/bootstrap/slapd-init.sh
+++ b/bootstrap/slapd-init.sh
@@ -12,6 +12,8 @@ readonly LDAP_SECRET=GoodNewsEveryone
 readonly LDAP_SSL_KEY="/etc/ldap/ssl/ldap.key"
 readonly LDAP_SSL_CERT="/etc/ldap/ssl/ldap.crt"
 
+readonly CERT_SAN="${CERT_SAN:-DNS:${LDAP_DOMAIN}}"
+
 
 reconfigure_slapd() {
     echo "Reconfigure slapd..."
@@ -38,6 +40,7 @@ EOL
 make_snakeoil_certificate() {
     echo "Make snakeoil certificate for ${LDAP_DOMAIN}..."
     openssl req -subj "/CN=${LDAP_DOMAIN}" \
+                -addext "subjectAltName = ${CERT_SAN}" \
                 -new \
                 -newkey rsa:2048 \
                 -days 365 \


### PR DESCRIPTION
With just the CN set in the snake oil certificate, Go clients refuse to
verify the certificate.

Can be overridden by specifying `--build-arg CERT_SAN=DNS:somehost.com`
when building the image. For example in test environments, it may be
useful to set it to `DNS:localhost` to avoid modifying `/etc/hosts` with
`planetexpress.com`. Multiple values can be specified, separated with
comma.