### PR TITLE
Adjusted `userProvider` in example `login.config` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ file you can use to connect.
 ```
 other {
   com.sun.security.auth.module.LdapLoginModule REQUIRED
-    userProvider="ldap://localhost/ou=people,dc=planetexpress,dc=com"
+    userProvider="ldap://localhost:10389/ou=people,dc=planetexpress,dc=com"
     userFilter="(&(uid={USERNAME})(objectClass=inetOrgPerson))"
     useSSL=false
     java.naming.security.principal="cn=admin,dc=planetexpress,dc=com"


### PR DESCRIPTION
In the `docker` given to start the container there is a port mapping for `10389` which is now reflected in the example `login.config`. It's now possible to simply copy / past this example and you're good to go.