### PR TITLE
Add a mail field to group ship_crew

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Amy has a multi-valued DN
 | ---------------- | ---------------- |
 | objectClass      | Group |
 | cn               | ship_crew |
+| mail             | ship_crew@planetexpress.com |
 | member           | cn=Turanga Leela,ou=people,dc=planetexpress,dc=com |
 | member           | cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com |
 | member           | cn=Bender Bending Rodríguez,ou=people,dc=planetexpress,dc=com |

--- a/rootfs/opt/openldap/bootstrap/data/30_groups_crew.ldif
+++ b/rootfs/opt/openldap/bootstrap/data/30_groups_crew.ldif
@@ -3,6 +3,7 @@ objectclass: Group
 objectclass: top
 groupType: 2147483650
 cn: ship_crew
+mail: ship_crew@planetexpress.com
 member: cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com
 member: cn=Turanga Leela,ou=people,dc=planetexpress,dc=com
 member: cn=Bender Bending Rodríguez,ou=people,dc=planetexpress,dc=com


### PR DESCRIPTION
It would be nice to have a mail field on the groups, since in many situation a group can represent a distribution list.

I've added it to the LDIF file, hopefully this is enough? I've ignored the admin group, so that the configuration differs a bit.