### PR TITLE
Fix for Issue 56

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,9 @@ EXPOSE 10389 10636
 
 CMD ["/init"]
 
-HEALTHCHECK CMD ["ldapsearch", "-H", "ldap://127.0.0.1:10389", "-D", "${LDAP_BINDDN}", "-w", "${LDAP_SECRET}", "-b", "${LDAP_BINDDN}"]
+# Add a healthcheck script
+RUN echo '#!/bin/sh' > /healthcheck.sh && \
+    echo 'ldapsearch -H ldap://127.0.0.1:10389 -D "${LDAP_BINDDN}" -w "${LDAP_SECRET}" -b "${LDAP_BINDDN}" >/dev/null 2>&1 || exit 1' >> /healthcheck.sh && \
+    chmod +x /healthcheck.sh
+
+HEALTHCHECK CMD /healthcheck.sh


### PR DESCRIPTION
Fix for Issue 56:

https://github.com/rroemhild/docker-test-openldap/issues/56

Docker does not automatically substitute environment variables in the HEALTHCHECK instruction.

add a line to create a health check script with the variables rendered, and adjusted the health check to execute that script.

```
67e1be24 slapd starting
[services.d] done.
67e1be3e conn=1000 fd=138 ACCEPT from IP=127.0.0.1:59546 (IP=0.0.0.0:10389)
67e1be3e conn=1000 op=0 BIND dn="cn=admin,dc=planetexpress,dc=com" method=128
67e1be3e conn=1000 op=0 BIND dn="cn=admin,dc=planetexpress,dc=com" mech=SIMPLE ssf=0
67e1be3e conn=1000 op=0 RESULT tag=97 err=0 text=
67e1be3e conn=1000 op=1 SRCH base="cn=admin,dc=planetexpress,dc=com" scope=2 deref=0 filter="(objectClass=*)"
67e1be3e conn=1000 op=1 SEARCH RESULT tag=101 err=0 nentries=1 text=
67e1be3e conn=1000 op=2 UNBIND
67e1be3e conn=1000 fd=138 closed
```